### PR TITLE
Line-break in ARK input placeholder

### DIFF
--- a/src/components/QueryInput/QueryInput.jsx
+++ b/src/components/QueryInput/QueryInput.jsx
@@ -145,8 +145,7 @@ export default function QueryInput () {
           rows='2'
           cols='30'
           name='queryInput'
-          placeholder='ark:/67375/0T8-JMF4G14B-2
-          ark:/67375/0T8-RNCBH0VZ-8'
+          placeholder='ark:/67375/0T8-JMF4G14B-2&#x0a;ark:/67375/0T8-RNCBH0VZ-8'
           value={arkInputValue}
           onChange={event => arkListHandler(event.target.value)}
         />


### PR DESCRIPTION
The character between the 2 ARK examples was a line-break in the code but it got converted to a simple space either by the JSX transpiler or the browser (I don't know...). This forces the character to be a Unix line-break (LF), which is the `&#x0a;` HTML entity.