### PR TITLE
Run GitHub action on `dev` branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,20 @@
 name: tests
 on:
   push:
-    branches: [ master, dev ]
+    branches: [master, dev]
   pull_request:
-    branches: [ master, dev ]
+    branches: [master, dev]
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out files
+        uses: actions/checkout@v2
+
       - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: '14'
+
       - name: Install dependencies and run tests
-        run: |
-          npm install
-          npm run test:ci
+        run: npm install && npm run test:ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: tests
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The GitHub action was originally only running on the `master` branch. It now also runs when pushing/merging on the `dev` branch.