### PR TITLE
Feature/custom usage translation

### DIFF
--- a/src/components/DownloadButton/DownloadButton.jsx
+++ b/src/components/DownloadButton/DownloadButton.jsx
@@ -74,8 +74,8 @@ export default function DownloadButton () {
       let format;
 
       // Cases of covers and annexes which are not in a category
-      if (Number.isInteger(formats[formatCategory])) {
-        format = formats[formatCategory];
+      if (formats[formatCategory].value !== undefined) {
+        format = formats[formatCategory].value;
 
         if (!isFormatSelected(selectedFormats, format)) continue;
 
@@ -87,8 +87,8 @@ export default function DownloadButton () {
         continue;
       }
 
-      for (const formatName in formats[formatCategory]) {
-        format = formats[formatCategory][formatName];
+      for (const formatName in formats[formatCategory].formats) {
+        format = formats[formatCategory].formats[formatName].value;
 
         if (!isFormatSelected(selectedFormats, format)) continue;
 

--- a/src/components/Format/Format.test.jsx
+++ b/src/components/Format/Format.test.jsx
@@ -6,12 +6,11 @@ import { formats } from '../../config';
 
 describe('Tests for the Format component', () => {
   it('Renders the PDF checkbox', () => {
-    const pdfFormatName = 'PDF';
-    const pdfFormatValue = formats.fulltext.pdf;
-    render(<Format name={pdfFormatName} value={pdfFormatValue} />);
+    const pdfFormat = formats.fulltext.formats.pdf;
+    render(<Format name={pdfFormat.label} value={pdfFormat.value} />);
     const pdfCheckbox = screen.getByRole('checkbox');
 
     expect(pdfCheckbox).toBeInTheDocument();
-    expect(pdfCheckbox.name).toBe(pdfFormatName);
+    expect(pdfCheckbox.name).toBe(pdfFormat.label);
   });
 });

--- a/src/components/Usage/Usage.test.jsx
+++ b/src/components/Usage/Usage.test.jsx
@@ -6,7 +6,7 @@ import { usages } from '../../config';
 
 describe('Tests for the PredefinedUsage component', () => {
   it('Renders the radio button', () => {
-    render(<Usage name='lodex' label={usages.lodex.label} formats={usages.lodex.value} />);
+    render(<Usage name='lodex' label={usages.lodex.label} formats={usages.lodex.selectedFormats} />);
     const radioButton = screen.getByText(/Lodex/i);
 
     expect(radioButton).toBeInTheDocument();

--- a/src/components/UsageSection/UsageSection.jsx
+++ b/src/components/UsageSection/UsageSection.jsx
@@ -17,8 +17,8 @@ export default function UsageSection () {
     if (!formats[categoryName]) return 0;
 
     let wholeCategoryFormat = 0;
-    for (const formatName in formats[categoryName]) {
-      wholeCategoryFormat = selectFormat(wholeCategoryFormat, formats[categoryName][formatName]);
+    for (const formatName in formats[categoryName].formats) {
+      wholeCategoryFormat = selectFormat(wholeCategoryFormat, formats[categoryName].formats[formatName].value);
     }
 
     return wholeCategoryFormat;
@@ -92,10 +92,10 @@ export default function UsageSection () {
               <div className='flex'>
                 {Object.keys(formats).map(formatCategory => {
                   // Cases of covers and annexes which are not in a category
-                  if (Number.isInteger(formats[formatCategory])) {
+                  if (formats[formatCategory].value !== undefined) {
                     return (
                       <div key={formatCategory}>
-                        <Format name={formatCategory} value={formats[formatCategory]} />
+                        <Format name={formats[formatCategory].label} value={formats[formatCategory].value} />
                       </div>
                     );
                   }
@@ -108,9 +108,14 @@ export default function UsageSection () {
                         onChange={toggleWholeCategory}
                         checked={isWholeCategorySelected(formatCategory)}
                       />
-                      <label htmlFor={formatCategory}>{formatCategory}</label>
-                      {Object.entries(formats[formatCategory]).map(([formatName, formatValue]) => (
-                        <Format key={formatName} name={formatName} value={formatValue} style={{ paddingLeft: '1em' }} />
+                      <label htmlFor={formatCategory}>{formats[formatCategory].label}</label>
+                      {Object.keys(formats[formatCategory].formats).map(formatName => (
+                        <Format
+                          key={formats[formatCategory].formats[formatName].label}
+                          name={formats[formatCategory].formats[formatName].label}
+                          value={formats[formatCategory].formats[formatName].value}
+                          style={{ paddingLeft: '1em' }}
+                        />
                       ))}
                     </div>
                   );

--- a/src/config.js
+++ b/src/config.js
@@ -55,28 +55,88 @@ export const istexApiConfig = {
 //      0        0       0000000000      0000000000     0000000000
 export const formats = {
   fulltext: {
-    pdf: 1 << 0,
-    tei: 1 << 1,
-    txt: 1 << 2,
-    cleaned: 1 << 3,
-    zip: 1 << 4,
-    tiff: 1 << 5,
+    label: 'Texte intégral',
+    formats: {
+      pdf: {
+        label: 'PDF',
+        value: 1 << 0,
+      },
+      tei: {
+        label: 'TEI',
+        value: 1 << 1,
+      },
+      txt: {
+        label: 'TXT',
+        value: 1 << 2,
+      },
+      cleaned: {
+        label: 'CLEANED',
+        value: 1 << 3,
+      },
+      zip: {
+        label: 'ZIP',
+        value: 1 << 4,
+      },
+      tiff: {
+        label: 'TIFF',
+        value: 1 << 5,
+      },
+    },
   },
   metadata: {
-    json: 1 << 10,
-    xml: 1 << 11,
-    mods: 1 << 12,
+    label: 'Métadonnées',
+    formats: {
+      json: {
+        label: 'JSON',
+        value: 1 << 10,
+      },
+      xml: {
+        label: 'XML',
+        value: 1 << 11,
+      },
+      mods: {
+        label: 'MODS',
+        value: 1 << 12,
+      },
+    },
   },
   enrichments: {
-    multicat: 1 << 20,
-    nb: 1 << 21,
-    grobidFulltext: 1 << 22,
-    refBibs: 1 << 23,
-    teeft: 1 << 24,
-    unitex: 1 << 25,
+    label: 'Enrichissements',
+    formats: {
+      multicat: {
+        label: 'multicat',
+        value: 1 << 20,
+      },
+      nb: {
+        label: 'nb',
+        value: 1 << 21,
+      },
+      grobidFulltext: {
+        label: 'grobidFulltext',
+        value: 1 << 22,
+      },
+      refBibs: {
+        label: 'refBibs',
+        value: 1 << 23,
+      },
+      teeft: {
+        label: 'teeft',
+        value: 1 << 24,
+      },
+      unitex: {
+        label: 'unitex',
+        value: 1 << 25,
+      },
+    },
   },
-  covers: 1 << 30,
-  annexes: 1 << 31,
+  covers: {
+    label: 'Couvertures',
+    value: 1 << 30,
+  },
+  annexes: {
+    label: 'Annexes',
+    value: 1 << 31,
+  },
 };
 
 export const usages = {
@@ -86,7 +146,7 @@ export const usages = {
   },
   lodex: {
     label: 'Lodex',
-    selectedFormats: formats.metadata.json,
+    selectedFormats: formats.metadata.formats.json.value,
   },
 };
 

--- a/src/lib/istexApi.js
+++ b/src/lib/istexApi.js
@@ -95,16 +95,16 @@ export function buildExtractParamsFromFormats (selectedFormats) {
     const currentCategoryParams = [];
 
     // Cases of covers and annexes which are not in a category
-    if (Number.isInteger(formats[formatCategory])) {
-      if (isFormatSelected(selectedFormats, formats[formatCategory])) {
+    if (formats[formatCategory].value !== undefined) {
+      if (isFormatSelected(selectedFormats, formats[formatCategory].value)) {
         extractParams.push(formatCategory);
       }
       continue;
     }
 
     // Build every format of the current category (e.g. pdf, txt for the fulltext category)
-    for (const currentCategoryFormat in formats[formatCategory]) {
-      if (isFormatSelected(selectedFormats, formats[formatCategory][currentCategoryFormat])) {
+    for (const currentCategoryFormat in formats[formatCategory].formats) {
+      if (isFormatSelected(selectedFormats, formats[formatCategory].formats[currentCategoryFormat].value)) {
         currentCategoryParams.push(currentCategoryFormat);
       }
     }
@@ -130,7 +130,7 @@ export function parseExtractParams (extractParamsAsString) {
   const formatCategories = extractParamsAsString.split(';')
     .filter(category => {
       // category would look like this: 'fulltext[txt,pdf]' so we
-      // need to make sure supportedFormatCategory is at the begging category
+      // need to make sure supportedFormatCategory is at the beginning of category
       for (const supportedFormatCategory in formats) {
         if (category.startsWith(supportedFormatCategory)) return true;
       }
@@ -143,8 +143,8 @@ export function parseExtractParams (extractParamsAsString) {
 
     // If formatCategory does not contain '[' and ']', it means it's 'covers' or 'annexes'
     if (indexOfOpeningBracket === -1 || indexOfClosingBracket === -1) {
-      if (Number.isInteger(formats[formatCategory])) {
-        selectedFormats = selectFormat(selectedFormats, formats[formatCategory]);
+      if (formats[formatCategory].value !== undefined) {
+        selectedFormats = selectFormat(selectedFormats, formats[formatCategory].value);
       }
       continue;
     }
@@ -155,10 +155,10 @@ export function parseExtractParams (extractParamsAsString) {
     // Get the formats within formatCategoryName and only keep the supported formats
     const currentCategoryFormats = formatCategory.substring(indexOfOpeningBracket + 1, indexOfClosingBracket)
       .split(',')
-      .filter(categoryFormat => Object.keys(formats[formatCategoryName]).includes(categoryFormat));
+      .filter(categoryFormat => Object.keys(formats[formatCategoryName].formats).includes(categoryFormat));
 
     for (const currentCategoryFormat of currentCategoryFormats) {
-      selectedFormats = selectFormat(selectedFormats, formats[formatCategoryName][currentCategoryFormat]);
+      selectedFormats = selectFormat(selectedFormats, formats[formatCategoryName].formats[currentCategoryFormat].value);
     }
   }
 

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -60,12 +60,12 @@ ark ark:/67375/NVC-8SNSRJ6Z-Z`;
   });
 
   it('buildExtractParamsFromFormats', () => {
-    const selectedFormats = formats.fulltext.pdf |
-      formats.fulltext.txt |
-      formats.enrichments.grobidFulltext |
-      formats.metadata.json |
-      formats.annexes |
-      formats.covers;
+    const selectedFormats = formats.fulltext.formats.pdf.value |
+      formats.fulltext.formats.txt.value |
+      formats.enrichments.formats.grobidFulltext.value |
+      formats.metadata.formats.json.value |
+      formats.annexes.value |
+      formats.covers.value;
     const noSelectedFormats = 0;
 
     expect(istexApi.buildExtractParamsFromFormats(selectedFormats)).toBe('fulltext[pdf,txt];metadata[json];enrichments[grobidFulltext];covers;annexes');
@@ -79,25 +79,25 @@ ark ark:/67375/NVC-8SNSRJ6Z-Z`;
     const missingCommaExtractParams = 'fulltext[pdf,txt];metadata[jsonxml];enrichments[teeft,nb]';
     const missingSemiColonExtractParams = 'fulltext[pdf,txt]metadata[json]';
 
-    expect(istexApi.parseExtractParams(correctExtractParams)).toBe(formats.fulltext.pdf |
-      formats.fulltext.txt |
-      formats.enrichments.grobidFulltext |
-      formats.metadata.json |
-      formats.annexes |
-      formats.covers);
-    expect(istexApi.parseExtractParams(wrongFormatExtractParams)).toBe(formats.metadata.json);
-    expect(istexApi.parseExtractParams(wrongCategoryExtractParams)).toBe(formats.fulltext.pdf);
-    expect(istexApi.parseExtractParams(missingCommaExtractParams)).toBe(formats.fulltext.pdf |
-      formats.fulltext.txt |
-      formats.enrichments.teeft |
-      formats.enrichments.nb);
-    expect(istexApi.parseExtractParams(missingSemiColonExtractParams)).toBe(formats.fulltext.pdf | formats.fulltext.txt);
+    expect(istexApi.parseExtractParams(correctExtractParams)).toBe(formats.fulltext.formats.pdf.value |
+      formats.fulltext.formats.txt.value |
+      formats.enrichments.formats.grobidFulltext.value |
+      formats.metadata.formats.json.value |
+      formats.annexes.value |
+      formats.covers.value);
+    expect(istexApi.parseExtractParams(wrongFormatExtractParams)).toBe(formats.metadata.formats.json.value);
+    expect(istexApi.parseExtractParams(wrongCategoryExtractParams)).toBe(formats.fulltext.formats.pdf.value);
+    expect(istexApi.parseExtractParams(missingCommaExtractParams)).toBe(formats.fulltext.formats.pdf.value |
+      formats.fulltext.formats.txt.value |
+      formats.enrichments.formats.teeft.value |
+      formats.enrichments.formats.nb.value);
+    expect(istexApi.parseExtractParams(missingSemiColonExtractParams)).toBe(formats.fulltext.formats.pdf.value | formats.fulltext.formats.txt.value);
   });
 
   it('buildFullApiUrl', () => {
     const queryStringRequest = {
       queryString: 'fulltext:fish',
-      selectedFormats: formats.fulltext.pdf,
+      selectedFormats: formats.fulltext.formats.pdf.value,
       rankingMode: istexApiConfig.rankingModes.getDefault().value,
       numberOfDocuments: 1,
       compressionLevel: istexApiConfig.compressionLevels.getDefault().value,
@@ -105,7 +105,7 @@ ark ark:/67375/NVC-8SNSRJ6Z-Z`;
     };
     const qIdRequest = {
       qId: 'fakeQId',
-      selectedFormats: formats.fulltext.pdf,
+      selectedFormats: formats.fulltext.formats.pdf.value,
       rankingMode: istexApiConfig.rankingModes.getDefault().value,
       numberOfDocuments: 1,
       compressionLevel: istexApiConfig.compressionLevels.getDefault().value,
@@ -121,19 +121,19 @@ ark ark:/67375/NVC-8SNSRJ6Z-Z`;
   });
 
   it('selectFormat', () => {
-    expect(istexApi.selectFormat(formats.fulltext.pdf, formats.fulltext.txt)).toBe(formats.fulltext.pdf | formats.fulltext.txt);
+    expect(istexApi.selectFormat(formats.fulltext.formats.pdf.value, formats.fulltext.formats.txt.value)).toBe(formats.fulltext.formats.pdf.value | formats.fulltext.formats.txt.value);
   });
 
   it('deselectFormat', () => {
-    expect(istexApi.deselectFormat(formats.fulltext.pdf | formats.fulltext.txt, formats.fulltext.txt)).toBe(formats.fulltext.pdf);
+    expect(istexApi.deselectFormat(formats.fulltext.formats.pdf.value | formats.fulltext.formats.txt.value, formats.fulltext.formats.txt.value)).toBe(formats.fulltext.formats.pdf.value);
   });
 
   it('toggleFormat', () => {
-    const formatsWithTxt = formats.fulltext.pdf | formats.fulltext.txt;
-    const formatsWithoutTxt = formats.fulltext.pdf;
+    const formatsWithTxt = formats.fulltext.formats.pdf.value | formats.fulltext.formats.txt.value;
+    const formatsWithoutTxt = formats.fulltext.formats.pdf.value;
 
-    expect(istexApi.toggleFormat(formatsWithoutTxt, formats.fulltext.txt)).toBe(formatsWithTxt);
-    expect(istexApi.toggleFormat(formatsWithTxt, formats.fulltext.txt)).toBe(formatsWithoutTxt);
+    expect(istexApi.toggleFormat(formatsWithoutTxt, formats.fulltext.formats.txt.value)).toBe(formatsWithTxt);
+    expect(istexApi.toggleFormat(formatsWithTxt, formats.fulltext.formats.txt.value)).toBe(formatsWithoutTxt);
   });
 
   it('noFormatSelected', () => {
@@ -141,10 +141,10 @@ ark ark:/67375/NVC-8SNSRJ6Z-Z`;
   });
 
   it('isFormatSelected', () => {
-    const formatsWithTxt = formats.fulltext.pdf | formats.fulltext.txt;
-    const formatsWithoutTxt = formats.fulltext.pdf;
+    const formatsWithTxt = formats.fulltext.formats.pdf.value | formats.fulltext.formats.txt.value;
+    const formatsWithoutTxt = formats.fulltext.formats.pdf.value;
 
-    expect(istexApi.isFormatSelected(formatsWithTxt, formats.fulltext.txt)).toBe(true);
-    expect(istexApi.isFormatSelected(formatsWithoutTxt, formats.fulltext.txt)).toBe(false);
+    expect(istexApi.isFormatSelected(formatsWithTxt, formats.fulltext.formats.txt.value)).toBe(true);
+    expect(istexApi.isFormatSelected(formatsWithoutTxt, formats.fulltext.formats.txt.value)).toBe(false);
   });
 });

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -16,7 +16,7 @@ describe('Tests for the utility functions', () => {
   it('buildFullIstexDlUrl', () => {
     const queryStringRequest = {
       queryString: 'fulltext:fish',
-      selectedFormats: formats.fulltext.pdf,
+      selectedFormats: formats.fulltext.formats.pdf.value,
       rankingMode: istexApiConfig.rankingModes.getDefault().value,
       numberOfDocuments: 1,
       compressionLevel: istexApiConfig.compressionLevels.getDefault().value,
@@ -34,7 +34,7 @@ describe('Tests for the utility functions', () => {
     };
     const qIdRequest = {
       qId: 'fakeQId',
-      selectedFormats: formats.fulltext.pdf,
+      selectedFormats: formats.fulltext.formats.pdf.value,
       rankingMode: istexApiConfig.rankingModes.getDefault().value,
       numberOfDocuments: 1,
       compressionLevel: istexApiConfig.compressionLevels.getDefault().value,


### PR DESCRIPTION
I applied the new config structure (with `label` and `value`) to the formats to translate the format categories and allow formats to display differently than their technical name in general.