### PR TITLE
review  de l'alignement du header Baseline et icones avec la marge du…

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -8,7 +8,7 @@ export default function Header () {
   return (
     <nav className='istex-header bg-white fixed w-full z-[1000]'>
       <div className='mx-auto'>
-        <div  style={{'paddingLeft': '215px', 'paddingRight': '215px'}} className='relative flex items-center justify-between px-10 py-10 md:pt-[22px] md:pb-[11px]'>
+        <div style={{ paddingLeft: '215px', paddingRight: '215px' }} className='relative flex items-center justify-between px-10 py-10 md:pt-[22px] md:pb-[11px]'>
           <div className='absolute inset-y-0 left-0 flex items-center sm:hidden'>
 
             {/* Mobile menu button */}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -8,7 +8,7 @@ export default function Header () {
   return (
     <nav className='istex-header bg-white fixed w-full z-[1000]'>
       <div className='mx-auto'>
-        <div className='relative flex items-center justify-between md:mx-[135px] md:px-[12px] md:pt-[22px] md:pb-[11px]'>
+        <div  style={{'paddingLeft': '215px', 'paddingRight': '215px'}} className='relative flex items-center justify-between px-10 py-10 md:pt-[22px] md:pb-[11px]'>
           <div className='absolute inset-y-0 left-0 flex items-center sm:hidden'>
 
             {/* Mobile menu button */}
@@ -37,7 +37,7 @@ export default function Header () {
               </svg>
             </button>
           </div>
-          <div className='flex w-full justify-between'>
+          <div className='flex w-full justify-around'>
             <div>
               <a className='flex flex-col justify-around' href='https://www.istex.fr'>
                 <img className='w-[184px]' src='/images/istex_logo.svg' alt='ISTEX' />

--- a/src/components/SubMenu/SubMenu.jsx
+++ b/src/components/SubMenu/SubMenu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function SubMenu () {
   return (
-    <ul className='font-montserrat-extrabold flex gap-12 font-[14px]'>
+    <ul className='font-montserrat-bold flex gap-12 font-[14px]'>
       <li className='text-sm text-istcolor-grey-light border-b-[3px] border-b-transparent hover:text-istcolor-black hover:border-b-istcolor-green-light'>
         <a className='block pb-[8px]' href='https://www.istex.fr/la-base/'>La base</a>
       </li>


### PR DESCRIPTION

Revue de l'Alignement du header ( Baseline et icones ) avec la marge du contenu de la page en version desktop, et changement du font-weight ( en moins gras )de la police utilisée pour le menu dans le header . 

Avant : 

![image](https://user-images.githubusercontent.com/58211440/187468120-882e4c9f-fb43-471a-aca3-64bdd9f074ec.png)

Après modification :
![image](https://user-images.githubusercontent.com/58211440/187467298-bd1ec08e-5805-4979-9ed9-906900bbecd3.png)

