### PR TITLE
[#75] Add new css rules for the share, download and history  istex modals

### DIFF
--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -47,3 +47,17 @@ input[type=number]::-webkit-outer-spin-button {
 [data-testid=modal] {
   z-index: 3000;
 }
+
+.istex-modal{
+  &__header {
+    background-color: #458CA5;  
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+    border-bottom-left-radius: 0rem;
+    border-bottom-right-radius: 0rem;
+  } 
+  &__text {
+    color: #fefefe;
+    font-weight: 700;
+  }
+}

--- a/src/components/DownloadButton/ModalDownloadRewiews.jsx
+++ b/src/components/DownloadButton/ModalDownloadRewiews.jsx
@@ -16,9 +16,13 @@ export default function ModalDownloadRewiews ({ initOpening = false, setOpenModa
         show={open}
         onClose={onClose}
       >
-        <Modal.Header>
-          Téléchargement en cours
-        </Modal.Header>
+        <div className='istex-modal__header'>
+          <Modal.Header>
+            <span className='istex-modal__text'>
+              Téléchargement en cours
+            </span>
+          </Modal.Header>
+        </div>
         <Modal.Body>
           <div className='flex flex-col justify-between items-center'>
             <p>

--- a/src/components/HistoryButton/HistoryButton.css
+++ b/src/components/HistoryButton/HistoryButton.css
@@ -18,13 +18,14 @@
 }
 
 .close {
-  color: #aaa;
+  color: #fefefe;
   float: right;
   font-size: 28px;
   font-weight: bold;
 }
 
-.close:hover, .close:focus {
+.close:hover,
+.close:focus {
   color: black;
   text-decoration: none;
   cursor: pointer;

--- a/src/components/HistoryButton/ModalListHistory.jsx
+++ b/src/components/HistoryButton/ModalListHistory.jsx
@@ -27,9 +27,13 @@ export default function ModalListHistory ({ show, onClose: setOpenModal, request
         onClose={onClose}
         size='7xl'
       >
-        <Modal.Header>
-          Historique des requêtes
-        </Modal.Header>
+        <div className='istex-modal__header'>
+          <Modal.Header className='istex-modal__header'>
+            <span className='istex-modal__text'>
+              Historique des requêtes
+            </span>
+          </Modal.Header>
+        </div>
         <Modal.Body>
           <div className='h-[220px] md:h-[300px] overflow-auto'>
             <Table hoverable>

--- a/src/components/ShareButton/ModalShareButton.jsx
+++ b/src/components/ShareButton/ModalShareButton.jsx
@@ -16,9 +16,13 @@ export default function ModalShareButton ({ initOpening = false, urlToClipboard 
         show={open}
         onClose={onClose}
       >
-        <Modal.Header>
-          Partager
-        </Modal.Header>
+        <div className='istex-modal__header'>
+          <Modal.Header>
+            <span className='istex-modal__text'>
+              Partager
+            </span>
+          </Modal.Header>
+        </div>
         <Modal.Body>
           <div className='space-y-6'>
             <div


### PR DESCRIPTION
This feature add new css rules for the share, download and history istex modals

History : 
![image](https://user-images.githubusercontent.com/58211440/190386280-8a0aacbc-9232-4fcb-aac1-73899ab271f7.png)

Share: 
![image](https://user-images.githubusercontent.com/58211440/190387465-4c13972c-5fae-4916-ac6c-99b554326a02.png)


Telechargement : 
![image](https://user-images.githubusercontent.com/58211440/190390455-99a92178-24e8-4de2-b145-5ceacf04bbc8.png)


