### PR TITLE
feat: add CorText usage

### DIFF
--- a/src/components/Usage/Usage.jsx
+++ b/src/components/Usage/Usage.jsx
@@ -43,6 +43,7 @@ export default function Usage ({ name, formats, label }) {
                       className={`text-xs ${name === 'lodex' ? 'pt-3' : 'pt-0'}`}
                     >
                       {name === 'lodex' && 'Analyse graphique / Exploration de corpus'}
+                      {name === 'cortext' && 'Plateforme d\'outils / Analyse multidimensionnelle'}
                     </RadioGroup.Description>
                   </div>
                 </div>

--- a/src/components/Usage/Usage.jsx
+++ b/src/components/Usage/Usage.jsx
@@ -5,13 +5,13 @@ import { RadioGroup } from '@headlessui/react';
 
 import eventEmitter, { events } from '../../lib/eventEmitter';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-export default function Usage ({ name, label, description, formats }) {
+export default function Usage ({ usageInfo }) {
   const usage = useSelector(state => state.istexApi.usage);
 
   const usageChangedHandler = value => {
     const newUsage = value;
 
-    eventEmitter.emit(events.setSelectedFormats, formats);
+    eventEmitter.emit(events.setSelectedFormats, usageInfo.selectedFormats);
     eventEmitter.emit(events.setUsage, newUsage);
   };
 
@@ -23,7 +23,7 @@ export default function Usage ({ name, label, description, formats }) {
       name='usages'
     >
       <RadioGroup.Option
-        value={name}
+        value={usageInfo.name}
         className='flex relative flex-col text-xl justify-between items-center focus:outline-none h-[270px] md:w-[340px]'
       >
         {({ active, checked }) => (
@@ -36,35 +36,29 @@ export default function Usage ({ name, label, description, formats }) {
                       as='p'
                       className='text-2xl font-montserrat-semibold text-istcolor-black'
                     >
-                      {label}
+                      {usageInfo.label}
                     </RadioGroup.Label>
                     <RadioGroup.Description
                       as='span'
                       className='text-xs pt-3'
                     >
-                      {description}
+                      {usageInfo.description}
                     </RadioGroup.Description>
                   </div>
                 </div>
               </div>
-              {name === 'customUsage' && (
-                <div className='flex flex-col absolute right-6 top-6'>
-                  <span className='text-xs font-montserrat-regular font-bold p-2 text-center text-istcolor-grey-link bg-istcolor-white'>DOC</span>
-                  <p className='text-xs font-montserrat-regular font-bold p-2 text-center text-istcolor-grey-link bg-istcolor-white'>TDM</p>
-                </div>
-              )}
-              {name === 'lodex' && (
-                <div className='flex flex-col absolute right-6 top-6'>
-                  <p className='text-xs font-montserrat-regular font-bold p-2 text-center text-istcolor-grey-link bg-istcolor-white'>TDM</p>
-                </div>
-              )}
+              <div className='flex flex-col absolute right-6 top-6'>
+                {usageInfo.tags.map(tag => (
+                  <span key={tag} className='text-xs font-montserrat-regular font-bold p-2 text-center text-istcolor-grey-link bg-istcolor-white'>{tag}</span>
+                ))}
+              </div>
             </div>
             <div className={`flex justify-center text-white p-4 ${checked ? ' bg-istcolor-green-dark' : 'bg-istcolor-blue cta1'} w-full`}>
               {checked && (
                 <FontAwesomeIcon icon='check' />
               )}
               <p>
-                {checked ? <span className='pl-2 text-sm font-montserrat-bold'>Usage sélectioné</span> : <span className='pl-2 text-sm font-montserrat-bold'>Choisir cet usage</span>}
+                {checked ? <span className='pl-2 text-sm font-montserrat-bold'>Usage sélectionné</span> : <span className='pl-2 text-sm font-montserrat-bold'>Choisir cet usage</span>}
               </p>
             </div>
           </>
@@ -75,8 +69,5 @@ export default function Usage ({ name, label, description, formats }) {
 }
 
 Usage.propTypes = {
-  name: PropTypes.string,
-  label: PropTypes.string,
-  description: PropTypes.string,
-  formats: PropTypes.number,
+  usageInfo: PropTypes.object,
 };

--- a/src/components/Usage/Usage.jsx
+++ b/src/components/Usage/Usage.jsx
@@ -5,7 +5,7 @@ import { RadioGroup } from '@headlessui/react';
 
 import eventEmitter, { events } from '../../lib/eventEmitter';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-export default function Usage ({ name, formats, label }) {
+export default function Usage ({ name, label, description, formats }) {
   const usage = useSelector(state => state.istexApi.usage);
 
   const usageChangedHandler = value => {
@@ -40,10 +40,9 @@ export default function Usage ({ name, formats, label }) {
                     </RadioGroup.Label>
                     <RadioGroup.Description
                       as='span'
-                      className={`text-xs ${name === 'lodex' ? 'pt-3' : 'pt-0'}`}
+                      className='text-xs pt-3'
                     >
-                      {name === 'lodex' && 'Analyse graphique / Exploration de corpus'}
-                      {name === 'cortext' && 'Plateforme d\'outils / Analyse multidimensionnelle'}
+                      {description}
                     </RadioGroup.Description>
                   </div>
                 </div>
@@ -78,5 +77,6 @@ export default function Usage ({ name, formats, label }) {
 Usage.propTypes = {
   name: PropTypes.string,
   label: PropTypes.string,
+  description: PropTypes.string,
   formats: PropTypes.number,
 };

--- a/src/components/Usage/Usage.test.jsx
+++ b/src/components/Usage/Usage.test.jsx
@@ -4,9 +4,9 @@ import { customRender as render, screen } from '../../test/utils';
 import Usage from './Usage';
 import { usages } from '../../config';
 
-describe('Tests for the PredefinedUsage component', () => {
+describe('Tests for the Usage component', () => {
   it('Renders the radio button', () => {
-    render(<Usage name='lodex' label={usages.lodex.label} formats={usages.lodex.selectedFormats} />);
+    render(<Usage usageInfo={{ name: 'lodex', ...usages.lodex }} />);
     const radioButton = screen.getByText(/Lodex/i);
 
     expect(radioButton).toBeInTheDocument();

--- a/src/components/UsageSection/UsageSection.jsx
+++ b/src/components/UsageSection/UsageSection.jsx
@@ -167,13 +167,7 @@ export default function UsageSection () {
           >
             {shouldDisplayUsage && (
               <div onClick={() => { handleDisplayingOfUsage(usageName); }}>
-                <Usage
-                  name={usageName}
-                  label={usages[usageName].label}
-                  description={usages[usageName].description}
-                  formats={usages[usageName].selectedFormats}
-                  setShouldDisplayUsage={setShouldDisplayUsage}
-                />
+                <Usage usageInfo={{ name: usageName, ...usages[usageName] }} />
               </div>
             )}
             {/* Check if the current usage being rendered (usageName) and the current selected usage (currentUsage)

--- a/src/components/UsageSection/UsageSection.jsx
+++ b/src/components/UsageSection/UsageSection.jsx
@@ -170,6 +170,7 @@ export default function UsageSection () {
                 <Usage
                   name={usageName}
                   label={usages[usageName].label}
+                  description={usages[usageName].description}
                   formats={usages[usageName].selectedFormats}
                   setShouldDisplayUsage={setShouldDisplayUsage}
                 />

--- a/src/config.js
+++ b/src/config.js
@@ -142,14 +142,17 @@ export const formats = {
 export const usages = {
   customUsage: {
     label: 'Usage personnalisé',
+    description: '',
     selectedFormats: 0,
   },
   lodex: {
     label: 'Lodex',
+    description: 'Analyse graphique / Exploration de corpus',
     selectedFormats: formats.metadata.formats.json.value,
   },
   cortext: {
     label: 'CorText',
+    description: 'Plateforme d\'outils / Analyse multidimensionnelle',
     selectedFormats: formats.fulltext.formats.tei.value |
       formats.fulltext.formats.cleaned.value |
       formats.enrichments.formats.teeft.value,

--- a/src/config.js
+++ b/src/config.js
@@ -144,11 +144,13 @@ export const usages = {
     label: 'Usage personnalisé',
     description: '',
     selectedFormats: 0,
+    tags: ['DOC', 'TDM'],
   },
   lodex: {
     label: 'Lodex',
     description: 'Analyse graphique / Exploration de corpus',
     selectedFormats: formats.metadata.formats.json.value,
+    tags: ['TDM'],
   },
   cortext: {
     label: 'CorText',
@@ -156,6 +158,7 @@ export const usages = {
     selectedFormats: formats.fulltext.formats.tei.value |
       formats.fulltext.formats.cleaned.value |
       formats.enrichments.formats.teeft.value,
+    tags: ['TDM'],
   },
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -148,6 +148,12 @@ export const usages = {
     label: 'Lodex',
     selectedFormats: formats.metadata.formats.json.value,
   },
+  cortext: {
+    label: 'CorText',
+    selectedFormats: formats.fulltext.formats.tei.value |
+      formats.fulltext.formats.cleaned.value |
+      formats.enrichments.formats.teeft.value,
+  },
 };
 
 export const operatorsRequest = [


### PR DESCRIPTION
This PR adds a new usage for the CorText platform and offers a more generic way of handling usage descriptions and tags (DOC, TDM).