### PR TITLE
fix(assisted-search): fixed the confirm button being enabled even before the user enters a value

### DIFF
--- a/src/components/AdvancedSearchForm/FormFields/DateField/DateField.jsx
+++ b/src/components/AdvancedSearchForm/FormFields/DateField/DateField.jsx
@@ -5,14 +5,15 @@ import { Spinner } from 'flowbite-react';
 
 function DateField ({ data, updateQuery, onChange, onCloseChoiceInputModal }) {
   const [value, setValue] = useState('');
-  const [selectedOption, setSelectedOption] = useState('');
+  const [selectedOption, setSelectedOption] = useState(null);
   const [intervalInputMaxValue, setIntervalInputMaxValue] = useState(100);
   const [intervalInputMinValue, setIntervalInputMinValue] = useState(0);
   const [isLoading, setLoading] = useState(true);
   const [optionsValue, setOptionsValue] = useState([]);
 
   const handleChange = (item) => {
-    setValue(item.value);
+    // item.value is of type number and needs to be casted to a string to be set in value
+    setValue(`${item.value}`);
     setSelectedOption(item);
   };
 
@@ -42,7 +43,7 @@ function DateField ({ data, updateQuery, onChange, onCloseChoiceInputModal }) {
     setLoading(true);
     const optionsValue = [];
 
-    for (let i = intervalInputMaxValue; i--; i >= intervalInputMinValue) {
+    for (let i = intervalInputMaxValue; i >= intervalInputMinValue; i--) {
       optionsValue.push({
         value: i, label: `${i}`,
       });
@@ -95,20 +96,21 @@ function DateField ({ data, updateQuery, onChange, onCloseChoiceInputModal }) {
       <div className='text-center'>
         <button
           type='button'
+          className={`p-2 ml-2 text-white bg-istcolor-blue border focus:ring-4 focus:outline-none ${value === '' ? 'bg-istcolor-grey-medium cursor-not-allowed' : 'border-istcolor-blue cta1'}`}
+          disabled={value === ''}
           onClick={(e) => {
             e.preventDefault();
             updateQuery(`${data.dataValue}:${value}`, value);
           }}
-          className='p-2 ml-2 text-white bg-istcolor-blue border border-istcolor-blue cta1 focus:ring-4 focus:outline-none'
         >
           Valider
         </button>
         <button
           type='button'
+          className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
           onClick={() => {
             onCloseChoiceInputModal();
           }}
-          className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
         >
           Annuler
         </button>

--- a/src/components/AdvancedSearchForm/FormFields/NumberField/NumberField.jsx
+++ b/src/components/AdvancedSearchForm/FormFields/NumberField/NumberField.jsx
@@ -29,20 +29,21 @@ function NumberField ({ data, updateQuery, onChange, onCloseChoiceInputModal }) 
       <div className='text-center'>
         <button
           type='button'
+          className={`p-2 ml-2 text-white bg-istcolor-blue border focus:ring-4 focus:outline-none ${value === '' ? 'bg-istcolor-grey-medium cursor-not-allowed' : 'border-istcolor-blue cta1'}`}
+          disabled={value === ''}
           onClick={(e) => {
             e.preventDefault();
-            updateQuery(`${data.dataValue}:${value}`);
+            updateQuery(`${data.dataValue}:${value}`, value);
           }}
-          className='p-2 ml-2 text-white bg-istcolor-blue border border-istcolor-blue cta1 focus:ring-4 focus:outline-none'
         >
           Valider
         </button>
         <button
           type='button'
+          className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
           onClick={() => {
             onCloseChoiceInputModal();
           }}
-          className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
         >
           Annuler
         </button>

--- a/src/components/AdvancedSearchForm/FormFields/RangeField/RangeField.jsx
+++ b/src/components/AdvancedSearchForm/FormFields/RangeField/RangeField.jsx
@@ -167,20 +167,20 @@ function RangeField ({
         >
           <button
             type='button'
+            className='p-2 ml-2 text-white bg-istcolor-blue border border-istcolor-blue cta1 focus:ring-4 focus:outline-none'
             onClick={(e) => {
               e.preventDefault();
               updateQuery(`${intervalInputData.dataValue}:[${minValue} TO ${maxValue}]`, `${minValue} à ${maxValue}`);
             }}
-            className='p-2 ml-2 text-white bg-istcolor-blue border border-istcolor-blue cta1 focus:ring-4 focus:outline-none'
           >
             Valider
           </button>
           <button
             type='button'
+            className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
             onClick={() => {
               onCloseChoiceInputModal();
             }}
-            className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
           >
             Annuler
           </button>

--- a/src/components/AdvancedSearchForm/FormFields/TextField/TextField.jsx
+++ b/src/components/AdvancedSearchForm/FormFields/TextField/TextField.jsx
@@ -44,20 +44,21 @@ function TextField ({ data, updateQuery, onChange, onCloseChoiceInputModal }) {
       <div className='text-center'>
         <button
           type='button'
+          className={`p-2 ml-2 text-white bg-istcolor-blue border focus:ring-4 focus:outline-none ${value === '' ? 'bg-istcolor-grey-medium cursor-not-allowed' : 'border-istcolor-blue cta1'}`}
+          disabled={value === ''}
           onClick={(e) => {
             e.preventDefault();
             updateQueryString();
           }}
-          className='p-2 ml-2 text-white bg-istcolor-blue border border-istcolor-blue cta1 focus:ring-4 focus:outline-none'
         >
           Valider
         </button>
         <button
           type='button'
+          className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
           onClick={() => {
             onCloseChoiceInputModal();
           }}
-          className='p-2 ml-2 text-white bg-istcolor-red border border-istcolor-red cta2 focus:ring-4 focus:outline-none'
         >
           Annuler
         </button>


### PR DESCRIPTION
This PR disables the confirm button when no value is entered in the modal. It also provides a fix for an unexpected type coercion that was displaying an error message in the console.