### PR TITLE
fix(assisted-search): surrounded all values sent to the API with double-quotes

### DIFF
--- a/src/components/AdvancedSearchForm/FormFields/TextField/TextField.jsx
+++ b/src/components/AdvancedSearchForm/FormFields/TextField/TextField.jsx
@@ -9,10 +9,8 @@ function TextField ({ data, updateQuery, onChange, onCloseChoiceInputModal }) {
   };
 
   const updateQueryString = () => {
-    const reWhiteSpace = (/\s/);
-
-    // The value entered by the user needs to be surrounded by double-quotes (") if it contains a space character
-    const valueToPutInQuery = reWhiteSpace.test(value) ? `"${value}"` : value;
+    // The value entered by the user needs to be surrounded by double-quotes (")
+    const valueToPutInQuery = `"${value}"`;
 
     if (data.dataValue === '') {
       updateQuery(valueToPutInQuery, value);


### PR DESCRIPTION
This PR surrounds field values with double-quotes in all cases. This makes sure the most common search case is "guaranteed".

Example:
- `author.name:"jean-michel"` will make sure all results have at least one author with a name containing "jean" **AND** "michel", which is probably what users want most of the time.
- `author.name:jean-michel` will return documents that have authors with names containing either "jean" **OR** "michel". A document written by "Jean Dupont" and "Michel Durand" would be in the results with this request, which is probably not what users want most of the time.