### PR TITLE
fix(formats): fixed all formats being selected when calling the resetForm function

### DIFF
--- a/src/components/ResetButton/ResetButton.jsx
+++ b/src/components/ResetButton/ResetButton.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { istexApiConfig, queryModes } from '../../config';
 import eventEmitter, { events } from '../../lib/eventEmitter';
-import { resetFormatSelected } from '../../lib/istexApi';
+import { noFormatSelected } from '../../lib/istexApi';
 
 export function resetForm () {
   eventEmitter.emit(events.setQueryMode, queryModes.getDefault().value);
@@ -12,7 +12,7 @@ export function resetForm () {
   eventEmitter.emit(events.setQId, '');
   eventEmitter.emit(events.setNumberOfDocuments, 0);
   eventEmitter.emit(events.setRankingMode, istexApiConfig.rankingModes.getDefault().value);
-  eventEmitter.emit(events.setSelectedFormats, resetFormatSelected());
+  eventEmitter.emit(events.setSelectedFormats, noFormatSelected());
   eventEmitter.emit(events.setCompressionLevel, istexApiConfig.compressionLevels.getDefault().value);
   eventEmitter.emit(events.setArchiveType, istexApiConfig.archiveTypes.getDefault().value);
   eventEmitter.emit(events.setUsage, '');

--- a/src/components/UsageSection/UsageSection.jsx
+++ b/src/components/UsageSection/UsageSection.jsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Tooltip } from 'flowbite-react';
 import Usage from '../Usage/Usage';
 import { setSelectedFormats, setUsage } from '../../store/istexApiSlice';
-import { buildExtractParamsFromFormats, deselectFormat, isFormatSelected, noFormatSelected, resetFormatSelected, selectFormat } from '../../lib/istexApi';
+import { buildExtractParamsFromFormats, deselectFormat, isFormatSelected, selectFormat } from '../../lib/istexApi';
 import eventEmitter, { events } from '../../lib/eventEmitter';
 import { formats, usages } from '../../config';
 import TitleSection from '../TitleSection/TitleSection';
@@ -65,20 +65,20 @@ export default function UsageSection () {
   };
 
   const selectedFormatsHandler = (newSelectedFormats) => {
-    // if user resets form
-    const isResetForm = newSelectedFormats === resetFormatSelected();
-    if (isResetForm) {
-      setShouldDisplayUsage(true);
-    }
-
     dispatch(setSelectedFormats(newSelectedFormats));
-    eventEmitter.emit(events.setSelectedFormatsInLastRequestOfHistory, isResetForm ? noFormatSelected() : newSelectedFormats);
+    eventEmitter.emit(events.setSelectedFormatsInLastRequestOfHistory, newSelectedFormats);
 
     const extractParams = buildExtractParamsFromFormats(newSelectedFormats);
     eventEmitter.emit(events.setExtractUrlParam, extractParams);
   };
 
   const usageHandler = newUsage => {
+    // newUsage is an empty string when the format gets reset and we want to display
+    // the different usages again in that case
+    if (newUsage === '') {
+      setShouldDisplayUsage(true);
+    }
+
     dispatch(setUsage(newUsage));
 
     eventEmitter.emit(events.setUsageUrlParam, newUsage);

--- a/src/lib/istexApi.js
+++ b/src/lib/istexApi.js
@@ -243,14 +243,6 @@ export function noFormatSelected () {
 }
 
 /**
- * Returns a negative value for differencing of no format selected.
- * @returns A format corresponding to reset form (-1).
- */
-export function resetFormatSelected () {
-  return -1;
-}
-
-/**
  * Check if `formatToCheck` is selected in `baseFormat`.
  * @param {number} baseFormat The format to check in.
  * @param {number} formatToCheck Teh format to check.


### PR DESCRIPTION
This PR fixes the bug where all formats where getting selected when calling the `resetForm` function (which happened when changing the query mode for instance).