### PR TITLE
feat(corpus-files): support for Istex IDs in `.corpus` files

### DIFF
--- a/src/components/QueryInput/QueryInput.jsx
+++ b/src/components/QueryInput/QueryInput.jsx
@@ -4,7 +4,7 @@ import md5 from 'crypto-js/md5';
 import PropTypes from 'prop-types';
 import { RadioGroup } from '@headlessui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Spinner, Tooltip } from 'flowbite-react';
+import { Tooltip } from 'flowbite-react';
 import TextareaAutosize from 'react-textarea-autosize';
 
 import { setQueryString, setQId } from '../../store/istexApiSlice';
@@ -12,7 +12,7 @@ import {
   buildQueryStringFromArks,
   isArkQueryString,
   getArksFromArkQueryString,
-  buildQueryStringFromCorpusFile,
+  parseCorpusFileContent,
   getQueryStringFromQId,
 } from '../../lib/istexApi';
 import eventEmitter, { events } from '../../lib/eventEmitter';
@@ -170,14 +170,14 @@ export default function QueryInput ({ totalAmountOfDocuments }) {
     reader.readAsText(file, 'utf-8');
     reader.onload = event => {
       const result = event.target.result;
-      const queryString = buildQueryStringFromCorpusFile(result);
+      const { numberOfIds, queryString } = parseCorpusFileContent(result);
       updateQueryString(queryString);
 
       setShouldDisplaySuccessMsg(true);
-      setFileInfo(prev => ({
-        ...prev,
+      setFileInfo({
         fileName: file.name,
-      }));
+        numberOfIds,
+      });
 
       eventEmitter.emit(events.displayNotification, {
         text: `import du fichier ${file.name} terminé`,
@@ -203,13 +203,6 @@ export default function QueryInput ({ totalAmountOfDocuments }) {
     eventEmitter.addListener(events.resetMessageImportCorpus, handleResetMessageImportCorpus);
     eventEmitter.addListener(events.addFocusOnInput, handleFocusOnInput);
   }, []);
-
-  useEffect(() => {
-    setFileInfo(prev => ({
-      ...prev,
-      numberOfIds: totalAmountOfDocuments,
-    }));
-  }, [totalAmountOfDocuments]);
 
   let queryInputUi;
   switch (currentQueryMode) {
@@ -268,7 +261,7 @@ export default function QueryInput ({ totalAmountOfDocuments }) {
             </label>
             {shouldDisplaySuccessMsg && (
               <p className='mt-4 border-2 p-2 text-white bg-istcolor-green-dark border-istcolor-green-dark'>
-                Fichier <span className='font-bold'>{fileInfo.fileName}</span> analysé. {fileInfo.numberOfIds ? <span className='font-bold'>{fileInfo.numberOfIds}</span> : <Spinner size='xs' color='warning' />} identifiants ont été parcourus. (Attention, le nombre des documents disponibles au téléchargement peut être inférieur si
+                Fichier <span className='font-bold'>{fileInfo.fileName}</span> analysé. <span className='font-bold'>{fileInfo.numberOfIds}</span> identifiants ont été parcourus. (Attention, le nombre des documents disponibles au téléchargement peut être inférieur si
                 certains identifiants ne sont pas trouvés par le moteur de recherche)
               </p>
             )}

--- a/src/lib/istexApi.js
+++ b/src/lib/istexApi.js
@@ -2,11 +2,13 @@ import axios from 'axios';
 import { istexApiConfig, formats } from '../config';
 
 /**
- * Build the query string to request the documents in `corpusFileContent`.
+ * Parse `corpusFileContent` to get the number of identifiers and build the corresponding query string
+ * to send to the API.
  * @param {string} corpusFileContent The .corpus file contents.
- * @returns The query string to request the documents in the .corpus file.
+ * @returns An object providing the number of parsed identifiers and the corresponding query string
+ * to send to the API.
  */
-export function buildQueryStringFromCorpusFile (corpusFileContent) {
+export function parseCorpusFileContent (corpusFileContent) {
   const lines = corpusFileContent.split('\n');
   const arks = [];
   const istexIds = [];
@@ -50,7 +52,10 @@ export function buildQueryStringFromCorpusFile (corpusFileContent) {
     queryString.push(buildQueryStringFromIstexIds(istexIds));
   }
 
-  return queryString.join(' OR ');
+  return {
+    numberOfIds: arks.length + istexIds.length,
+    queryString: queryString.join(' OR '),
+  };
 }
 
 /**

--- a/src/lib/istexApi.js
+++ b/src/lib/istexApi.js
@@ -25,9 +25,9 @@ export function parseCorpusFileContent (corpusFileContent) {
     // so we can break out of the loop
     if (line === '[ISTEX]') break;
 
-    // Split the line to get an arrays like ['ark', '<ark>', ...] or ['id', '<id>']
+    // Split the line to get arrays like ['ark', '<ark>', ...] or ['id', '<id>', ...]
     const lineSegments = line
-      .split('#')[0] // Only keep that is before the potential comment
+      .split('#')[0] // Only keep what is before the potential comment
       .split(' ') // Separate the words
       .filter(token => token !== ''); // Remove the empty strings
 
@@ -60,7 +60,7 @@ export function parseCorpusFileContent (corpusFileContent) {
 
 /**
  * Build the query string to request the Istex IDs in `istexIds`
- * @param {*} istexIds The array containing the Istex IDs
+ * @param {string[]} istexIds The array containing the Istex IDs
  * @returns A properly formatted query string to request the Istex IDs in `istexIds`
  */
 export function buildQueryStringFromIstexIds (istexIds) {

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -4,7 +4,7 @@ import { istexApiConfig, formats } from '../config';
 
 describe('Tests for the ISTEX API related functions', () => {
   it('buildQueryStringFromCorpusFile', () => {
-    const corpusFileContent =
+    const completeCorpusFileContent =
 `#
 # Fichier .corpus
 #
@@ -12,11 +12,51 @@ query        : *
 date         : 2022-3-11
 total        : 5
 [ISTEX]
-ark ark:/67375/NVC-S58LP3M2-S
-ark ark:/67375/NVC-RBP335V7-7
-ark ark:/67375/NVC-8SNSRJ6Z-Z`;
 
-    expect(istexApi.buildQueryStringFromCorpusFile(corpusFileContent)).toBe('arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S")');
+ark   ark:/67375/NVC-S58LP3M2-S    # very cool comment
+garbage line
+ark ark:/67375/NVC-RBP335V7-7    # very cool comment
+
+ark  ark:/67375/NVC-8SNSRJ6Z-Z    # very cool comment
+id    B940A8D3FD96AB383C6393070933764A2CE3D106   # very cool comment
+id CAE51D9B29CBA1B8C81A136946C75A51055C7066  # very cool comment
+id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
+
+    const onlyArksCorpusFileContent =
+`#
+# Fichier .corpus
+#
+query        : *
+date         : 2022-3-11
+total        : 5
+[ISTEX]
+
+ark   ark:/67375/NVC-S58LP3M2-S    # very cool comment
+garbage line
+ark ark:/67375/NVC-RBP335V7-7    # very cool comment
+ark  ark:/67375/NVC-8SNSRJ6Z-Z    # very cool comment`;
+
+    const onlyIstexIdsCorpusFileContent =
+`#
+# Fichier .corpus
+#
+query        : *
+date         : 2022-3-11
+total        : 5
+[ISTEX]
+id    B940A8D3FD96AB383C6393070933764A2CE3D106   # very cool comment
+garbage line
+id CAE51D9B29CBA1B8C81A136946C75A51055C7066  # very cool comment
+id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
+
+    const completeExpectedQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S") OR id:("59E080581FC0350BC92AD9975484E4127E8803A0" "CAE51D9B29CBA1B8C81A136946C75A51055C7066" "B940A8D3FD96AB383C6393070933764A2CE3D106")';
+    expect(istexApi.buildQueryStringFromCorpusFile(completeCorpusFileContent)).toBe(completeExpectedQueryString);
+
+    const onlyArksExpectedQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S")';
+    expect(istexApi.buildQueryStringFromCorpusFile(onlyArksCorpusFileContent)).toBe(onlyArksExpectedQueryString);
+
+    const onlyIstexIdsExpectedQueryString = 'id:("59E080581FC0350BC92AD9975484E4127E8803A0" "CAE51D9B29CBA1B8C81A136946C75A51055C7066" "B940A8D3FD96AB383C6393070933764A2CE3D106")';
+    expect(istexApi.buildQueryStringFromCorpusFile(onlyIstexIdsCorpusFileContent)).toBe(onlyIstexIdsExpectedQueryString);
   });
 
   it('buildQueryStringFromArks', () => {

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import * as istexApi from './istexApi';
 import { istexApiConfig, formats } from '../config';
 
-describe('Tests for the ISTEX API related functions', () => {
-  it('buildQueryStringFromCorpusFile', () => {
+describe('Tests for the Istex API related functions', () => {
+  it('parseCorpusFileContent', () => {
     const completeCorpusFileContent =
 `#
 # Fichier .corpus
@@ -50,13 +50,19 @@ id CAE51D9B29CBA1B8C81A136946C75A51055C7066  # very cool comment
 id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
 
     const completeExpectedQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S") OR id:("59E080581FC0350BC92AD9975484E4127E8803A0" "CAE51D9B29CBA1B8C81A136946C75A51055C7066" "B940A8D3FD96AB383C6393070933764A2CE3D106")';
-    expect(istexApi.buildQueryStringFromCorpusFile(completeCorpusFileContent)).toBe(completeExpectedQueryString);
+    const parsedCompleteCorpusFileContent = istexApi.parseCorpusFileContent(completeCorpusFileContent);
+    expect(parsedCompleteCorpusFileContent.queryString).toBe(completeExpectedQueryString);
+    expect(parsedCompleteCorpusFileContent.numberOfIds).toBe(6);
 
     const onlyArksExpectedQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S")';
-    expect(istexApi.buildQueryStringFromCorpusFile(onlyArksCorpusFileContent)).toBe(onlyArksExpectedQueryString);
+    const parsedOnlyArksCorpusFileContent = istexApi.parseCorpusFileContent(onlyArksCorpusFileContent);
+    expect(parsedOnlyArksCorpusFileContent.queryString).toBe(onlyArksExpectedQueryString);
+    expect(parsedOnlyArksCorpusFileContent.numberOfIds).toBe(3);
 
     const onlyIstexIdsExpectedQueryString = 'id:("59E080581FC0350BC92AD9975484E4127E8803A0" "CAE51D9B29CBA1B8C81A136946C75A51055C7066" "B940A8D3FD96AB383C6393070933764A2CE3D106")';
-    expect(istexApi.buildQueryStringFromCorpusFile(onlyIstexIdsCorpusFileContent)).toBe(onlyIstexIdsExpectedQueryString);
+    const parsedOnlyIstexIdsCorpusFileContent = istexApi.parseCorpusFileContent(onlyIstexIdsCorpusFileContent);
+    expect(parsedOnlyIstexIdsCorpusFileContent.queryString).toBe(onlyIstexIdsExpectedQueryString);
+    expect(parsedOnlyIstexIdsCorpusFileContent.numberOfIds).toBe(3);
   });
 
   it('buildQueryStringFromArks', () => {

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -72,7 +72,19 @@ id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
       'ark:/67375/NVC-S58LP3M2-S ',
     ];
 
-    expect(istexApi.buildQueryStringFromArks(arks)).toBe('arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S")');
+    const expectedQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S")';
+    expect(istexApi.buildQueryStringFromArks(arks)).toBe(expectedQueryString);
+  });
+
+  it('buildQueryStringFromIstexIds', () => {
+    const istexIds = [
+      '59E080581FC0350BC92AD9975484E4127E8803A0',
+      'CAE51D9B29CBA1B8C81A136946C75A51055C7066',
+      'B940A8D3FD96AB383C6393070933764A2CE3D106',
+    ];
+
+    const expectedQueryString = 'id:("59E080581FC0350BC92AD9975484E4127E8803A0" "CAE51D9B29CBA1B8C81A136946C75A51055C7066" "B940A8D3FD96AB383C6393070933764A2CE3D106")';
+    expect(istexApi.buildQueryStringFromIstexIds(istexIds)).toBe(expectedQueryString);
   });
 
   it('isArkQueryString', () => {


### PR DESCRIPTION
This PR changes the `.corpus` file parser to support Istex IDs and comments at the end of lines. It also changes the number of documents displayed in a success message once the file is parsed, the number of IDs parsed is now displayed instead of the number of documents actually returned by the API.