### PR TITLE
feat(arks): add syntax check on ARK identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eventemitter3": "^4.0.7",
         "flowbite": "^1.5.1",
         "flowbite-react": "^0.1.3",
+        "inist-ark": "^2.1.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-popper": "^2.3.0",
@@ -3786,7 +3787,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -4219,6 +4219,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/inist-ark": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/inist-ark/-/inist-ark-2.1.3.tgz",
+      "integrity": "sha512-ra+tw+eL8wMeRgoBLrsec7kHJ1ykSkh9Wn2oGTDX7ljbzNeN7He4+nTPwCPSNSjWTBbWtv+8sLg1UfO96jHrtQ=="
     },
     "node_modules/inquirer": {
       "version": "8.2.4",
@@ -9104,6 +9109,7 @@
     },
     "eslint-config-standard-react": {
       "version": "git+ssh://git@github.com/standard/eslint-config-standard-react.git#f4524992516ede26dc2d4264966acb6bd6744d66",
+      "integrity": "sha512-vmjjhae1DBQIfGEkfr5ZCrD/FQ2Zl4zkikbUBXZQ3RNMwnFIViyD9sM1Ehgy6YAVgD6P+tvRagRlHMEEtNeuHw==",
       "dev": true,
       "from": "eslint-config-standard-react@github:standard/eslint-config-standard-react",
       "requires": {}
@@ -9615,7 +9621,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -9925,6 +9930,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "inist-ark": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/inist-ark/-/inist-ark-2.1.3.tgz",
+      "integrity": "sha512-ra+tw+eL8wMeRgoBLrsec7kHJ1ykSkh9Wn2oGTDX7ljbzNeN7He4+nTPwCPSNSjWTBbWtv+8sLg1UfO96jHrtQ=="
     },
     "inquirer": {
       "version": "8.2.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eventemitter3": "^4.0.7",
     "flowbite": "^1.5.1",
     "flowbite-react": "^0.1.3",
+    "inist-ark": "^2.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-popper": "^2.3.0",

--- a/src/components/ExampleQueryButton/ModalExampleQueryButton.jsx
+++ b/src/components/ExampleQueryButton/ModalExampleQueryButton.jsx
@@ -34,7 +34,19 @@ export default function ModalExampleQueryButton ({
       setArkInputValue(params.input);
 
       const arks = params.input.split('\n');
-      const queryString = buildQueryStringFromArks(arks);
+
+      let queryString;
+      try {
+        queryString = buildQueryStringFromArks(arks);
+      } catch (err) {
+        eventEmitter.emit(events.displayNotification, {
+          text: `Erreur de syntaxe dans l'ARK à la ligne ${err.line}`,
+          type: 'error',
+        });
+
+        return;
+      }
+
       updateQueryString(queryString);
     } else {
       setQueryStringInputValue(params.input);

--- a/src/components/QueryInput/QueryInput.jsx
+++ b/src/components/QueryInput/QueryInput.jsx
@@ -157,7 +157,19 @@ export default function QueryInput ({ totalAmountOfDocuments }) {
     }
 
     const arks = arkList.split('\n');
-    const queryString = buildQueryStringFromArks(arks);
+
+    let queryString;
+    try {
+      queryString = buildQueryStringFromArks(arks);
+    } catch (err) {
+      eventEmitter.emit(events.displayNotification, {
+        text: `Erreur de syntaxe dans l'ARK à la ligne ${err.line}`,
+        type: 'error',
+      });
+
+      return;
+    }
+
     updateQueryString(queryString);
   };
 
@@ -170,7 +182,20 @@ export default function QueryInput ({ totalAmountOfDocuments }) {
     reader.readAsText(file, 'utf-8');
     reader.onload = event => {
       const result = event.target.result;
-      const { numberOfIds, queryString } = parseCorpusFileContent(result);
+
+      let parsingResult;
+      try {
+        parsingResult = parseCorpusFileContent(result);
+      } catch (err) {
+        eventEmitter.emit(events.displayNotification, {
+          text: `Erreur de syntaxe dans l'ARK à la ligne ${err.line}`,
+          type: 'error',
+        });
+
+        return;
+      }
+
+      const { numberOfIds, queryString } = parsingResult;
       updateQueryString(queryString);
 
       setShouldDisplaySuccessMsg(true);

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -97,24 +97,12 @@ id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
     expect(istexApi.isArkQueryString(garbageString)).toBe(false);
   });
 
-  it('isEmptyArkQueryString', () => {
-    const emptyArkQueryString = 'arkIstex.raw:("")';
-    const nonEmptyArkQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z")';
-    const garbageInput = 'some garbage data';
-
-    expect(istexApi.isEmptyArkQueryString(emptyArkQueryString)).toBe(true);
-    expect(istexApi.isEmptyArkQueryString(nonEmptyArkQueryString)).toBe(false);
-    expect(istexApi.isEmptyArkQueryString(garbageInput)).toBe(false);
-  });
-
   it('getArksFromArkQueryString', () => {
     const singleArkQueryString = 'arkIstex.raw:("ark:/67375/NVC-15SZV86B-F")';
     const multipleArkQueryString = 'arkIstex.raw:("ark:/67375/NVC-15SZV86B-F" "ark:/67375/NVC-XMM4B8LD-H")';
-    const garbageString = 'foo:bar';
 
     expect(istexApi.getArksFromArkQueryString(singleArkQueryString)).toEqual(['ark:/67375/NVC-15SZV86B-F']);
     expect(istexApi.getArksFromArkQueryString(multipleArkQueryString)).toEqual(['ark:/67375/NVC-15SZV86B-F', 'ark:/67375/NVC-XMM4B8LD-H']);
-    expect(istexApi.getArksFromArkQueryString(garbageString)).toBe(null);
   });
 
   it('buildExtractParamsFromFormats', () => {


### PR DESCRIPTION
This PR adds a syntax check on ARK identifiers when using them through the "Identifiants ARK" tab or within a `.corpus` file. It also removes the `isEmptyArkQueryString` function that was not used anymore.