### PR TITLE
fix(arks): fixed the `.corpus` file parser

### DIFF
--- a/src/lib/istexApi.js
+++ b/src/lib/istexApi.js
@@ -12,6 +12,7 @@ const InistArk = new InistArkConstructor();
  * to send to the API.
  */
 export function parseCorpusFileContent (corpusFileContent) {
+  const validIdTypes = ['ark', 'id'];
   const lines = corpusFileContent.split('\n');
   const arks = [];
   const istexIds = [];
@@ -34,9 +35,16 @@ export function parseCorpusFileContent (corpusFileContent) {
       .split(' ') // Separate the words
       .filter(token => token !== ''); // Remove the empty strings
 
-    // If the line contains less than 2 segments, it means it does not have the format 'ark <ark>' or 'id <id>'
-    // so we just skip it
-    if (lineSegments.length < 2) continue;
+    // At this point, if lineSegments is empty, it means the line was not an empty string but only
+    // contained spaces and this is not seen as an error
+    if (lineSegments.length === 0) continue;
+
+    // The first segment of the line needs to be a valid ID type
+    if (!validIdTypes.includes(lineSegments[0])) {
+      const err = new Error('Syntax error');
+      err.line = i + 1;
+      throw err;
+    }
 
     const [idType, idValue] = lineSegments;
 

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -14,7 +14,6 @@ total        : 5
 [ISTEX]
 
 ark   ark:/67375/NVC-S58LP3M2-S    # very cool comment
-garbage line
 ark ark:/67375/NVC-RBP335V7-7    # very cool comment
 
 ark  ark:/67375/NVC-8SNSRJ6Z-Z    # very cool comment
@@ -32,7 +31,6 @@ total        : 5
 [ISTEX]
 
 ark   ark:/67375/NVC-S58LP3M2-S    # very cool comment
-garbage line
 ark ark:/67375/NVC-RBP335V7-7    # very cool comment
 ark  ark:/67375/NVC-8SNSRJ6Z-Z    # very cool comment`;
 
@@ -45,9 +43,23 @@ date         : 2022-3-11
 total        : 5
 [ISTEX]
 id    B940A8D3FD96AB383C6393070933764A2CE3D106   # very cool comment
-garbage line
 id CAE51D9B29CBA1B8C81A136946C75A51055C7066  # very cool comment
 id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
+
+    const invalidLineCorpusFileContent =
+`#
+# Fichier .corpus
+#
+query        : *
+date         : 2022-3-11
+total        : 5
+[ISTEX]
+ark  ark:/67375/NVC-S58LP3M2-S
+   
+garbage line
+
+ark  ark:/67375/NVC-RBP335V7-7
+ark  ark:/67375/NVC-8SNSRJ6Z-Z`;
 
     const completeExpectedQueryString = 'arkIstex.raw:("ark:/67375/NVC-8SNSRJ6Z-Z" "ark:/67375/NVC-RBP335V7-7" "ark:/67375/NVC-S58LP3M2-S") OR id:("59E080581FC0350BC92AD9975484E4127E8803A0" "CAE51D9B29CBA1B8C81A136946C75A51055C7066" "B940A8D3FD96AB383C6393070933764A2CE3D106")';
     const parsedCompleteCorpusFileContent = istexApi.parseCorpusFileContent(completeCorpusFileContent);
@@ -63,6 +75,8 @@ id  59E080581FC0350BC92AD9975484E4127E8803A0 # very cool comment`;
     const parsedOnlyIstexIdsCorpusFileContent = istexApi.parseCorpusFileContent(onlyIstexIdsCorpusFileContent);
     expect(parsedOnlyIstexIdsCorpusFileContent.queryString).toBe(onlyIstexIdsExpectedQueryString);
     expect(parsedOnlyIstexIdsCorpusFileContent.numberOfIds).toBe(3);
+
+    expect(() => istexApi.parseCorpusFileContent(invalidLineCorpusFileContent)).toThrow();
   });
 
   it('buildQueryStringFromArks', () => {


### PR DESCRIPTION
The `.corpus` file parser was made more restrictive to throw an error when a line is not empty after all spaces are removed and does not start with "ark" or "id".