### PR TITLE
feat: support for Istex IDs in the ARK tab

### DIFF
--- a/src/components/QueryInput/QueryInput.jsx
+++ b/src/components/QueryInput/QueryInput.jsx
@@ -14,6 +14,8 @@ import {
   getArksFromArkQueryString,
   parseCorpusFileContent,
   getQueryStringFromQId,
+  isIstexIdQueryString,
+  getIstexIdsFromIstexIdQueryString,
 } from '../../lib/istexApi';
 import eventEmitter, { events } from '../../lib/eventEmitter';
 import { queryModes, istexApiConfig } from '../../config';
@@ -60,9 +62,19 @@ export default function QueryInput ({ totalAmountOfDocuments }) {
       setArkInputValue('');
     }
 
-    if (isArkQueryString(newQueryString)) {
-      const arkList = getArksFromArkQueryString(newQueryString).join('\n');
-      setArkInputValue(arkList);
+    const _isArkQueryString = isArkQueryString(newQueryString);
+    const _isIstexIdQueryString = isIstexIdQueryString(newQueryString);
+
+    // Very strange legacy behavior where the ARK tab is also supposed to support Istex IDs... Would be nice
+    // to remove in the future
+    if (_isArkQueryString || _isIstexIdQueryString) {
+      let list;
+      if (_isArkQueryString) {
+        list = getArksFromArkQueryString(newQueryString).join('\n');
+      } else if (_isIstexIdQueryString) {
+        list = getIstexIdsFromIstexIdQueryString(newQueryString).join('\n');
+      }
+      setArkInputValue(list);
       setCurrentQueryMode(queryModes.modes.find(queryMode => queryMode.value === 'ark').value);
     } else {
       setCurrentQueryMode(queryModes.getDefault().value);

--- a/src/lib/istexApi.js
+++ b/src/lib/istexApi.js
@@ -117,7 +117,7 @@ export function buildQueryStringFromArks (arks) {
  * @returns `true` if `queryString` has the format `arkIstex.raw:("<ark1>" "<ark2>"...)`, `false` otherwise.
  */
 export function isArkQueryString (queryString) {
-  // Regex to check if queryString starts with 'arkIstex.raw:(', ends with '(', and contains sequences of
+  // Regex to check if queryString starts with 'arkIstex.raw:(', ends with ')', and contains sequences of
   // characters surrounded by double-quotes between the parentheses. This doesn't make sure each sequence of
   // characters is a valid ark.
   const arkQueryStringRegex = /^(?:arkIstex\.raw:\((?:".*"?)*\))$/gi;
@@ -135,7 +135,7 @@ export function isArkQueryString (queryString) {
 /**
  * Extract ark identifiers from an ark query string. This assumes `queryString` is an ark query string.
  * @param {string} queryString The query string the extract the ark identifiers from.
- * @returns An array of ark identifiers, `null` if `queryString` is not an ark query string.
+ * @returns An array of ark identifiers.
  */
 export function getArksFromArkQueryString (queryString) {
   // Get rid of 'arkIstex.raw:(' at the beginning of queryString
@@ -145,6 +145,38 @@ export function getArksFromArkQueryString (queryString) {
   queryString = queryString.substring(0, queryString.length - 1);
 
   // Get rid of the double-quotes (") surrounding each ark identifier
+  queryString = queryString.replace(/"/g, '');
+
+  return queryString.split(' ');
+}
+
+/**
+ * Check if `queryString` has the format `id:("<id1>" "<id2>"...)`.
+ * @param {string} queryString The query string to check.
+ * @returns `true` if `queryString` has the format `id:("<id1>" "<id2>"...)`, `false` otherwise.
+ */
+export function isIstexIdQueryString (queryString) {
+  // Regex to check if queryString starts with 'id:(', ends with ')', and contains sequences of
+  // characters surrounded by double-quotes between the parentheses. This doesn't make sure each sequence of
+  // characters is a valid Istex ID.
+  const istexIdQueryStringRegex = /^(?:id:\((?:".*"?)*\))$/gi;
+
+  return istexIdQueryStringRegex.test(queryString);
+}
+
+/**
+ * Extract Istex identifiers from an Istex ID query string. This assumes `queryString` is an Istex ID query string.
+ * @param {string} queryString The query string the extract the Istex identifiers from.
+ * @returns An array of Istex identifiers.
+ */
+export function getIstexIdsFromIstexIdQueryString (queryString) {
+  // Get rid of 'id:(' at the beginning of queryString
+  queryString = queryString.substring('id:('.length);
+
+  // Get rid of the last parenthesis at the end of queryString
+  queryString = queryString.substring(0, queryString.length - 1);
+
+  // Get rid of the double-quotes (") surrounding each Istex identifier
   queryString = queryString.replace(/"/g, '');
 
   return queryString.split(' ');

--- a/src/lib/istexApi.test.js
+++ b/src/lib/istexApi.test.js
@@ -119,6 +119,22 @@ ark  ark:/67375/NVC-8SNSRJ6Z-Z`;
     expect(istexApi.getArksFromArkQueryString(multipleArkQueryString)).toEqual(['ark:/67375/NVC-15SZV86B-F', 'ark:/67375/NVC-XMM4B8LD-H']);
   });
 
+  it('isIstexIdQueryString', () => {
+    const correctIstexIdQueryString = 'id:("1234" "5678")';
+    const garbageString = 'foo:bar';
+
+    expect(istexApi.isIstexIdQueryString(correctIstexIdQueryString)).toBe(true);
+    expect(istexApi.isIstexIdQueryString(garbageString)).toBe(false);
+  });
+
+  it('getIstexIdsFromIstexIdQueryString', () => {
+    const singleIstexIdQueryString = 'id:("1234")';
+    const multipleIstexIdsQueryString = 'id:("1234" "5678")';
+
+    expect(istexApi.getIstexIdsFromIstexIdQueryString(singleIstexIdQueryString)).toEqual(['1234']);
+    expect(istexApi.getIstexIdsFromIstexIdQueryString(multipleIstexIdsQueryString)).toEqual(['1234', '5678']);
+  });
+
   it('buildExtractParamsFromFormats', () => {
     const selectedFormats = formats.fulltext.formats.pdf.value |
       formats.fulltext.formats.txt.value |


### PR DESCRIPTION
This PR adds support for Istex IDs in the ARK tab. Which means that editing/sharing requests that came from a `.corpus` file containing Istex IDs will switch to the ARK tab and fill the textarea with the list of Istex IDs.