### PR TITLE
fix: identifiers list

### DIFF
--- a/src/features/query/QueryInput.jsx
+++ b/src/features/query/QueryInput.jsx
@@ -143,17 +143,24 @@ export default function QueryInput () {
     const idTypeInfo = getIdTypeInfoFromId(ids[0]);
     let queryString;
 
-    if (idTypeInfo != null) {
-      try {
-        queryString = idTypeInfo.buildQueryString(ids);
-      } catch (err) {
-        eventEmitter.emit(events.displayNotification, {
-          text: `Erreurs de syntaxe aux lignes : ${err.lines.join(', ')}`,
-          type: 'error',
-        });
+    if (idTypeInfo == null) {
+      eventEmitter.emit(events.displayNotification, {
+        text: 'Erreurs de syntaxe aux lignes : 1',
+        type: 'error',
+      });
 
-        return;
-      }
+      return;
+    }
+
+    try {
+      queryString = idTypeInfo.buildQueryString(ids);
+    } catch (err) {
+      eventEmitter.emit(events.displayNotification, {
+        text: `Erreurs de syntaxe aux lignes : ${err.lines.join(', ')}`,
+        type: 'error',
+      });
+
+      return;
     }
 
     updateQueryString(queryString);


### PR DESCRIPTION
This PR fixes the error message missing when the identifier type was not found. This happened whenever a syntax error was in the first identifier of the list. It also brings a debounce of the identifiers parsing to avoid getting loads of syntax error messages when quickly introducing multiple syntax errors in a row.