### PR TITLE
feat: multiline search

### DIFF
--- a/cypress/e2e/home-page.cy.ts
+++ b/cypress/e2e/home-page.cy.ts
@@ -8,8 +8,8 @@ describe("The Home Page", () => {
   it("Valid search", () => {
     const queryString = "hello";
 
-    cy.get("input#regular-search-input").type(queryString);
-    cy.get("form").submit();
+    cy.get("textarea#regular-search-input").type(queryString);
+    cy.get("button[type=submit]").click();
     cy.wait(500);
     cy.url().should("include", `/results?q=${queryString}`);
   });

--- a/cypress/e2e/results-page.cy.ts
+++ b/cypress/e2e/results-page.cy.ts
@@ -8,7 +8,7 @@ describe("The Results Page", () => {
 
     it("Search", () => {
       cy.get("button#download-button").should("exist");
-      cy.get("input#regular-search-input").should("have.value", queryString);
+      cy.get("textarea#regular-search-input").should("have.value", queryString);
       cy.get("#results-grid").children().should("have.length.gt", 0);
     });
 

--- a/src/app/[locale]/(search)/components/SearchSection/RegularSearchInput.tsx
+++ b/src/app/[locale]/(search)/components/SearchSection/RegularSearchInput.tsx
@@ -4,6 +4,7 @@ import {
   type ChangeEventHandler,
   type FormEventHandler,
   useState,
+  type KeyboardEventHandler,
 } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next-intl/client";
@@ -23,7 +24,7 @@ const RegularSearchInput: ClientComponent = () => {
   const [queryString, setQueryString] = useState(searchParams.getQueryString());
   const [errorMessage, setErrorMessage] = useState("");
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+  const handleSubmit: FormEventHandler = (event) => {
     event.preventDefault();
 
     if (queryString.trim() === "") {
@@ -39,6 +40,15 @@ const RegularSearchInput: ClientComponent = () => {
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     setErrorMessage("");
     setQueryString(event.target.value);
+  };
+
+  const handleKeyDown: KeyboardEventHandler = (event) => {
+    // textarea elements don't submit the form when pressing Enter by default
+    // so we recreate this behavior but still allow to insert new lines by
+    // pressing Shift+Enter
+    if (event.code === "Enter" && !event.shiftKey) {
+      handleSubmit(event);
+    }
   };
 
   return (
@@ -57,11 +67,20 @@ const RegularSearchInput: ClientComponent = () => {
           placeholder={t("placeholder")}
           value={queryString}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           helperText={errorMessage}
           required
           autoFocus
           error={errorMessage !== ""}
           fullWidth
+          multiline
+          minRows={1}
+          maxRows={8}
+          inputProps={{
+            // Dirty hack to avoid a flicker with the input height, explained here
+            // https://github.com/mui/material-ui/issues/23031
+            style: { minHeight: 23 },
+          }}
           sx={{
             mb: { xs: 2, sm: 0 },
             // This targets the fieldset around the input

--- a/src/app/[locale]/(search)/components/SearchSection/RegularSearchInput.tsx
+++ b/src/app/[locale]/(search)/components/SearchSection/RegularSearchInput.tsx
@@ -4,13 +4,13 @@ import {
   type ChangeEventHandler,
   type FormEventHandler,
   useState,
-  type KeyboardEventHandler,
 } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next-intl/client";
 import { useSelectedLayoutSegment } from "next/navigation";
-import { Box, TextField, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Button from "@/components/Button";
+import MultilineTextField from "@/components/MultilineTextField";
 import useSearchParams from "@/lib/useSearchParams";
 import type { ClientComponent } from "@/types/next";
 
@@ -42,17 +42,8 @@ const RegularSearchInput: ClientComponent = () => {
     setQueryString(event.target.value);
   };
 
-  const handleKeyDown: KeyboardEventHandler = (event) => {
-    // textarea elements don't submit the form when pressing Enter by default
-    // so we recreate this behavior but still allow to insert new lines by
-    // pressing Shift+Enter
-    if (event.code === "Enter" && !event.shiftKey) {
-      handleSubmit(event);
-    }
-  };
-
   return (
-    <Box component="form" noValidate autoCorrect="off" onSubmit={handleSubmit}>
+    <Box component="form" noValidate autoCorrect="off">
       <Typography variant="h5" component="h1" gutterBottom>
         {urlSegment === "results" ? t("resultsTitle") : t("searchTitle")}
       </Typography>
@@ -62,25 +53,19 @@ const RegularSearchInput: ClientComponent = () => {
           textAlign: { xs: "center", sm: "inherit" },
         }}
       >
-        <TextField
+        <MultilineTextField
           id="regular-search-input"
           placeholder={t("placeholder")}
           value={queryString}
           onChange={handleChange}
-          onKeyDown={handleKeyDown}
+          onSubmit={handleSubmit}
           helperText={errorMessage}
           required
           autoFocus
           error={errorMessage !== ""}
           fullWidth
-          multiline
           minRows={1}
           maxRows={8}
-          inputProps={{
-            // Dirty hack to avoid a flicker with the input height, explained here
-            // https://github.com/mui/material-ui/issues/23031
-            style: { minHeight: 23 },
-          }}
           sx={{
             mb: { xs: 2, sm: 0 },
             // This targets the fieldset around the input

--- a/src/app/[locale]/(search)/components/SearchSection/RegularSearchInput.tsx
+++ b/src/app/[locale]/(search)/components/SearchSection/RegularSearchInput.tsx
@@ -43,7 +43,7 @@ const RegularSearchInput: ClientComponent = () => {
   };
 
   return (
-    <Box component="form" noValidate autoCorrect="off">
+    <Box component="form" noValidate autoCorrect="off" onSubmit={handleSubmit}>
       <Typography variant="h5" component="h1" gutterBottom>
         {urlSegment === "results" ? t("resultsTitle") : t("searchTitle")}
       </Typography>

--- a/src/components/MultilineTextField.tsx
+++ b/src/components/MultilineTextField.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { forwardRef, type KeyboardEventHandler } from "react";
+import { TextField, type TextFieldProps } from "@mui/material";
+import type { ClientComponent } from "@/types/next";
+
+const MultilineTextField: ClientComponent<TextFieldProps> = forwardRef(
+  function MultilineTextField(props, forwardedRef) {
+    const { onSubmit, ...rest } = props;
+
+    const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+      // textarea elements don't submit the form when pressing Enter by default
+      // so we recreate this behavior but still allow to insert new lines by
+      // pressing Shift+Enter
+      if (onSubmit != null && event.code === "Enter" && !event.shiftKey) {
+        onSubmit(event);
+      }
+    };
+
+    return (
+      <TextField
+        ref={forwardedRef}
+        onKeyDown={handleKeyDown}
+        multiline
+        inputProps={{
+          // Dirty hack to avoid a flicker with the input height, explained here
+          // https://github.com/mui/material-ui/issues/23031
+          style: { minHeight: 23 },
+        }}
+        {...rest}
+      />
+    );
+  }
+);
+
+export default MultilineTextField;


### PR DESCRIPTION
This PR changes the `RegularSearchInput` underline `<input>` to a `<textarea>` to allow multiline requests. Form submission is still possible by pressing `Enter` and new line insertion is bound to `Shift+Enter`, this logic had to be implemented manually.