### PR TITLE
build(docker): stop relying on  `$npm_package_version`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,27 +18,19 @@ COPY package.json ./
 COPY public ./public
 COPY scripts ./scripts
 COPY src ./src
-
-# Leave us alone with your telemetry
-ENV NEXT_TELEMETRY_DISABLED 1
 RUN npm run build
 
 
 FROM base AS runner
 WORKDIR /app
 
-# We still don't want your telemetry
-ENV NEXT_TELEMETRY_DISABLED 1
-
 # Create a group and a user to avoid being root in the container
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
-
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
 USER nextjs
 
-CMD ["node", "server.js"]
+# Copy the build from the previous stage and the start script
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./.next/standalone
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/start-prod-server.sh .
+
+CMD ["./start-prod-server.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   istex-dl:
     container_name: istex-dl
-    image: istex/istex-dl:${npm_package_version}
+    build: .
     ports:
       - 3000:3000

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "test:unit:watch": "jest --watch",
     "test:e2e": "cypress run",
     "test:e2e:watch": "cypress open",
-    "docker:build": "docker build -t istex/istex-dl:$npm_package_version .",
-    "docker:run": "docker compose up -d",
-    "docker:stop": "docker compose stop",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
This PR simplifies the build and run process using docker. The image is built by `compose` and not manually anymore, so no need to know what the current version number is.

**Note**: This probably will need to change in the future to tag the image properly when we'll need to upload it a to registry.